### PR TITLE
Simpler function binding

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,16 +4,8 @@ import installExtension, {
   REACT_DEVELOPER_TOOLS,
 } from 'electron-devtools-installer';
 import { updateElectronApp } from 'update-electron-app';
-import {
-  addConnectionToConfig,
-  changeTheme,
-  editConnection,
-  getConfiguration,
-  updateConnectionState,
-} from './configuration';
-import type { Configuration, ConnectionAppState } from './configuration/type';
+import { bindIpcMain as bindIpcMainConfiguration } from './configuration';
 import connectionStackInstance from './sql';
-import type { ConnectionObject } from './sql/types';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
@@ -82,33 +74,7 @@ app.whenReady().then(() => {
 
   installReactDevToolsExtension();
 
-  ipcMain.handle('config:get', getConfiguration);
-  ipcMain.handle(
-    'config:connection:add',
-    (event: unknown, connection: ConnectionObject): Configuration =>
-      addConnectionToConfig(connection)
-  );
-  ipcMain.handle(
-    'config:connection:edit',
-    (
-      event: unknown,
-      connectionName: string,
-      connection: ConnectionObject
-    ): Configuration => editConnection(connectionName, connection)
-  );
-  ipcMain.handle('config:theme:change', (event: unknown, name: string) =>
-    changeTheme(name)
-  );
-  ipcMain.handle(
-    'config:connection:updateState',
-    <K extends keyof ConnectionAppState>(
-      event: unknown,
-      connectionName: string,
-      key: K,
-      value: ConnectionAppState[K]
-    ) => updateConnectionState(connectionName, key, value)
-  );
-
+  bindIpcMainConfiguration(ipcMain);
   connectionStackInstance.bindIpcMain(ipcMain);
 
   // createWindow();

--- a/src/preload/bindChannel.ts
+++ b/src/preload/bindChannel.ts
@@ -1,0 +1,7 @@
+import { ipcRenderer } from 'electron';
+
+export function bindChannel(channel: string) {
+  return function (...args: unknown[]) {
+    return ipcRenderer.invoke(channel, ...args);
+  };
+}

--- a/src/preload/config.ts
+++ b/src/preload/config.ts
@@ -1,6 +1,7 @@
-import { ipcRenderer } from 'electron';
 import type { Configuration, ConnectionAppState } from '../configuration/type';
 import type { ConnectionObject } from '../sql/types';
+import { bindChannel } from './bindChannel';
+import { CONFIGURATION_CHANNEL } from './configurationChannel';
 
 interface Config {
   getConfiguration(): Promise<null | Configuration>;
@@ -22,22 +23,11 @@ interface Config {
 }
 
 export const config: Config = {
-  getConfiguration: () => ipcRenderer.invoke('config:get'),
-  addConnectionToConfig: (connection: ConnectionObject) =>
-    ipcRenderer.invoke('config:connection:add', connection),
-  editConnection: (connectionName: string, connection: ConnectionObject) =>
-    ipcRenderer.invoke('config:connection:edit', connectionName, connection),
-  changeTheme: (theme: string) =>
-    ipcRenderer.invoke('config:theme:change', theme),
-  updateConnectionState: <K extends keyof ConnectionAppState>(
-    connectionName: string,
-    key: K,
-    value: ConnectionAppState[K]
-  ) =>
-    ipcRenderer.invoke(
-      'config:connection:updateState',
-      connectionName,
-      key,
-      value
-    ),
+  getConfiguration: bindChannel(CONFIGURATION_CHANNEL.GET),
+  addConnectionToConfig: bindChannel(CONFIGURATION_CHANNEL.ADD_CONNECTION),
+  changeTheme: bindChannel(CONFIGURATION_CHANNEL.CHANGE_THEME),
+  updateConnectionState: bindChannel(
+    CONFIGURATION_CHANNEL.UPDATE_CONNECTION_STATE
+  ),
+  editConnection: bindChannel(CONFIGURATION_CHANNEL.EDIT_CONNECTION),
 };

--- a/src/preload/configurationChannel.ts
+++ b/src/preload/configurationChannel.ts
@@ -1,0 +1,7 @@
+export enum CONFIGURATION_CHANNEL {
+  GET = 'config:get',
+  ADD_CONNECTION = 'config:connection:add',
+  EDIT_CONNECTION = 'config:connection:edit',
+  CHANGE_THEME = 'config:theme:change',
+  UPDATE_CONNECTION_STATE = 'config:connection:updateState',
+}

--- a/src/preload/sql.ts
+++ b/src/preload/sql.ts
@@ -1,10 +1,11 @@
-import { ipcRenderer } from 'electron';
 import { Connection } from 'mysql2/promise';
 import type {
   ConnectionObject,
   QueryResult,
   QueryReturnType,
 } from '../sql/types';
+import { bindChannel } from './bindChannel';
+import { SQL_CHANNEL } from './sqlChannel';
 
 interface Sql {
   openConnection(params: ConnectionObject): Promise<Connection>;
@@ -12,9 +13,8 @@ interface Sql {
   closeAllConnections(): Promise<void>;
 }
 
-// TODO : clone the binder object in sql/index.ts ?
 export const sql: Sql = {
-  openConnection: (params) => ipcRenderer.invoke('sql:connect', params),
-  executeQuery: (query) => ipcRenderer.invoke('sql:executeQuery', query),
-  closeAllConnections: () => ipcRenderer.invoke('sql:closeAll'),
+  openConnection: bindChannel(SQL_CHANNEL.CONNECT),
+  executeQuery: bindChannel(SQL_CHANNEL.EXECUTE_QUERY),
+  closeAllConnections: bindChannel(SQL_CHANNEL.CLOSE_ALL),
 };

--- a/src/preload/sqlChannel.ts
+++ b/src/preload/sqlChannel.ts
@@ -1,0 +1,5 @@
+export enum SQL_CHANNEL {
+  CONNECT = 'sql:connect',
+  EXECUTE_QUERY = 'sql:executeQuery',
+  CLOSE_ALL = 'sql:closeAll',
+}

--- a/src/sql/index.ts
+++ b/src/sql/index.ts
@@ -1,4 +1,5 @@
 import { Connection, createConnection } from 'mysql2/promise';
+import { SQL_CHANNEL } from '../preload/sqlChannel';
 import { ConnectionObject, QueryResult } from './types';
 
 class ConnectionStack {
@@ -6,9 +7,9 @@ class ConnectionStack {
 
   // List of IPC events and their handlers
   #ipcEventBinding = {
-    'sql:connect': this.connect,
-    'sql:executeQuery': this.executeQuery,
-    'sql:closeAll': this.closeAllConnections,
+    [SQL_CHANNEL.CONNECT]: this.connect,
+    [SQL_CHANNEL.EXECUTE_QUERY]: this.executeQuery,
+    [SQL_CHANNEL.CLOSE_ALL]: this.closeAllConnections,
   };
 
   bindIpcMain(ipcMain: Electron.IpcMain): void {


### PR DESCRIPTION
Binding to ipc channel is awfully repetitive, and the channel name might contain typos.

Create a helper method that facilitate binding, and use TS enum to ensure there is no typos. 