### PR TITLE
Use react router action for sql raw query route

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -18,7 +18,7 @@ import ConnectionErrorPage from './routes/errors/ConnectionsErrorPage';
 import RootErrorPage from './routes/errors/RootErrorPage';
 import { Home } from './routes/home';
 import Root from './routes/root';
-import SqlPage from './routes/sql.$connectionName';
+import SqlPage, { action as sqlPageAction } from './routes/sql.$connectionName';
 
 const appElement = document.getElementById('App');
 
@@ -61,6 +61,9 @@ const router = createHashRouter([
       {
         path: 'connections/:connectionName',
         loader: connectionDetailPageLoader,
+        shouldRevalidate: ({ currentParams, nextParams }) => {
+          return currentParams.connectionName !== nextParams.connectionName;
+        },
         element: <ConnectionDetailPage />,
         children: [
           {
@@ -77,6 +80,7 @@ const router = createHashRouter([
               {
                 path: 'sql',
                 element: <SqlPage />,
+                action: sqlPageAction,
               },
             ],
           },

--- a/src/renderer/component/MonacoEditor/RawSqlEditor.tsx
+++ b/src/renderer/component/MonacoEditor/RawSqlEditor.tsx
@@ -51,6 +51,7 @@ export function RawSqlEditor({
         language: 'sql',
         theme: 'currentTheme',
         minimap: { enabled: false },
+        automaticLayout: true,
         ...memoizedMonacoOptions,
       });
 

--- a/src/renderer/routes/connections.$connectionName.tsx
+++ b/src/renderer/routes/connections.$connectionName.tsx
@@ -51,7 +51,7 @@ export async function loader({ params, request }: RouteParams) {
     openedTable ? `/tables/${openedTable}` : ''
   }`;
 
-  if (!request.url.endsWith(expectedUrl)) {
+  if (new URL(request.url).pathname !== expectedUrl) {
     return redirect(expectedUrl);
   }
 


### PR DESCRIPTION
When an error occured in raw sql page

<img width="696" alt="image" src="https://github.com/jdeniau/tiana-tables/assets/1398469/97544c76-a5b0-473c-918c-0cb155d87367">

A prefered style would be to handle error in the result page, and keep the input