### PR TITLE
Fix (?) timezone issue for datetime

### DIFF
--- a/src/renderer/component/Cell.stories.tsx
+++ b/src/renderer/component/Cell.stories.tsx
@@ -84,8 +84,15 @@ export const WithNumberType: Story = {
 
 export const WithDateType: Story = {
   args: {
+    type: Types.DATE,
+    value: new Date('2020-01-01T12:00:00'),
+  },
+};
+
+export const WithDatetimeType: Story = {
+  args: {
     type: Types.DATETIME,
-    value: new Date('Jan 20 2020'),
+    value: new Date('2020-01-01T12:00:00'),
   },
 };
 

--- a/src/renderer/component/Cell.tsx
+++ b/src/renderer/component/Cell.tsx
@@ -8,6 +8,7 @@ import {
   foreground,
   stringForeground,
 } from '../theme';
+import { formatDate, formatDateTime } from '../utils/dateFormatter';
 
 interface TableCellFactoryProps {
   type: number | undefined;
@@ -35,8 +36,12 @@ const ForegroundSpan = styled(BaseCell)`
   color: ${foreground};
 `;
 
+function DateCell({ value }: { value: Date }) {
+  return <ForegroundSpan>{formatDate(value)}</ForegroundSpan>;
+}
+
 function DatetimeCell({ value }: { value: Date }) {
-  return <ForegroundSpan>{value.toISOString()}</ForegroundSpan>;
+  return <ForegroundSpan>{formatDateTime(value)}</ForegroundSpan>;
 }
 
 const StringSpan = styled(BaseCell)`
@@ -76,9 +81,11 @@ function TableCellFactory({ type, value }: TableCellFactoryProps) {
     case Types.DATETIME2: // aka DATETIME with fractional seconds
     case Types.TIMESTAMP: // aka TIMESTAMP
     case Types.TIMESTAMP2: // aka TIMESTAMP with fractional seconds
-    case Types.DATE: // aka DATE
     case Types.NEWDATE: // aka ?
       return <DatetimeCell value={value} />;
+
+    case Types.DATE: // aka DATE
+      return <DateCell value={value} />;
 
     // Numbers
     case Types.TINY: // aka TINYINT, 1 byte

--- a/src/renderer/utils/dateFormatter.test.ts
+++ b/src/renderer/utils/dateFormatter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import { formatDate, formatDateTime } from './dateFormatter';
+
+describe('dateTiFormatter', () => {
+  test.each([
+    ['2021-01-01T00:00:00', '2021-01-01 00:00:00'],
+    ['2021-12-12T23:59:59', '2021-12-12 23:59:59'],
+  ])('formatDate(%s) should return %s', (date, expected) => {
+    expect(formatDateTime(new Date(date))).toBe(expected);
+  });
+
+  test.each([
+    ['2021-01-01T00:00:00', '2021-01-01'],
+    ['2021-12-12T23:59:59', '2021-12-12'],
+  ])('formatDate(%s) should return %s', (date, expected) => {
+    expect(formatDate(new Date(date))).toBe(expected);
+  });
+});

--- a/src/renderer/utils/dateFormatter.ts
+++ b/src/renderer/utils/dateFormatter.ts
@@ -1,0 +1,18 @@
+// This file is a small date formatter helper for now.
+// We might want to use a library like date-fns, luxoon or Temporal in the future.
+
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+export function formatDateTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  return `${formatDate(date)} ${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
objects from datetime and date columns are returned as Date objects, but Date objects [is just bad](https://julien.deniau.me/timezones/#/8/8). 

The mariadb timezone [can be specified on the system](https://mariadb.com/kb/en/time-zones/) and mysql library can [pass a timezone as connection option](https://github.com/mysqljs/mysql?tab=readme-ov-file#connection-options), but let's keep it simple for now : 

As Date are construct with "local" timezone, imagine the following date:

```js
d = new Date('2020-01-01 00:00:00')
// Date Wed Jan 01 2020 00:00:00 GMT+0100 (heure normale d’Europe centrale)
```

Formating this with `.toISOString()` will give us `"2019-12-31T23:00:00.000Z"` (ISO string is UTC+0 for JS), but we do want only the local value.

We do implement a small date utility function to format the date that use the "Y-m-d H:i:s" format.

In the future, we might want to use another library, like temporal, luxon or dare-fns, but for the moment the helper works fine 👌 