### PR TITLE
migrate electron-squirrel-startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@storybook/react": "^8.3.5",
     "@storybook/react-vite": "^8.3.5",
     "@storybook/test": "^8.3.5",
+    "@types/electron-squirrel-startup": "^1.0.2",
     "@types/mysql": "^2.15.26",
     "@types/node": "^20.16.11",
     "@types/react": "^18.3.11",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, Menu, app, ipcMain, session } from 'electron';
 import path from 'node:path';
 import log from 'electron-log/main';
+import started from 'electron-squirrel-startup';
 import { updateElectronApp } from 'update-electron-app';
 import {
   bindIpcMain as bindIpcMainConfiguration,
@@ -19,7 +20,7 @@ const isMac = isMacPlatform();
 const isDev = isDevApp();
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-if (require('electron-squirrel-startup')) {
+if (started) {
   app.quit();
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,6 +2536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/electron-squirrel-startup@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@types/electron-squirrel-startup@npm:1.0.2"
+  checksum: 10c0/d6d6b7b26ef1a0814f7fec15649032d3d518c961155ac3b8e08408d1fff6b08d0e1597ef2926ede34e37dee091129b72e064ba711820a91b3d9f12574a3666a8
+  languageName: node
+  linkType: hard
+
 "@types/escodegen@npm:^0.0.6":
   version: 0.0.6
   resolution: "@types/escodegen@npm:0.0.6"
@@ -11036,6 +11043,7 @@ __metadata:
     "@storybook/react": "npm:^8.3.5"
     "@storybook/react-vite": "npm:^8.3.5"
     "@storybook/test": "npm:^8.3.5"
+    "@types/electron-squirrel-startup": "npm:^1.0.2"
     "@types/mysql": "npm:^2.15.26"
     "@types/node": "npm:^20.16.11"
     "@types/react": "npm:^18.3.11"


### PR DESCRIPTION
Since vite-plugin 7.5, electron-squirrel-startup does not handle `require` 

See https://github.com/electron/forge/pull/3713