### PR TITLE
upgrade electron from v32 to v41

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^34.5.8",
+    "electron": "^35.7.5",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^35.7.5",
+    "electron": "^36.9.5",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^36.9.5",
+    "electron": "^37.10.3",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^33.4.11",
+    "electron": "^34.5.8",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^39.8.10",
+    "electron": "^40.10.0",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^40.10.0",
+    "electron": "^41.5.2",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
     "electron": "^41.5.2",
-    "electron-devtools-installer": "^3.2.0",
+    "electron-devtools-installer": "^4.0.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^32.1.2",
+    "electron": "^33.4.11",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^38.8.6",
+    "electron": "^39.8.10",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.2",
     "chromatic": "^11.0.0",
-    "electron": "^37.10.3",
+    "electron": "^38.8.6",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,9 +69,9 @@ const createWindow = () => {
 
   // Forward renderer console messages tagged "[startup]" to the main log file
   // so we can measure renderer startup in production builds.
-  mainWindow.webContents.on('console-message', (_event, _level, message) => {
-    if (message.includes('[startup]')) {
-      log.info(message);
+  mainWindow.webContents.on('console-message', (details) => {
+    if (details.message.includes('[startup]')) {
+      log.info(details.message);
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^37.10.3":
-  version: 37.10.3
-  resolution: "electron@npm:37.10.3"
+"electron@npm:^38.8.6":
+  version: 38.8.6
+  resolution: "electron@npm:38.8.6"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/a09c10d76be021a94f6c8b251ef990553fe530a6a1271c22026f06a502e977fac116a88b78e73abf50177386a76d69b1c9a52f62d6de60006cc50ed4cb969f0f
+  checksum: 10c0/4e3c02a01b99a77d715a28ec1b1053382860c3100a735adae5784387e38f7cb800313aeb2c9d292297f37237b57b8660bafcf913360a6b68865a45642a495264
   languageName: node
   linkType: hard
 
@@ -11062,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^37.10.3"
+    electron: "npm:^38.8.6"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^35.7.5":
-  version: 35.7.5
-  resolution: "electron@npm:35.7.5"
+"electron@npm:^36.9.5":
+  version: 36.9.5
+  resolution: "electron@npm:36.9.5"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/2c331e438b655b25a8b49ce038878cdc61a42481fcdf464ecb5648585a2c83f1edc5d8e0a8de582713f8e3dc8a3b35aaa136735ad68f8009ee2369f3b2e79c15
+  checksum: 10c0/85f7239e6912dba8dcab133b51c12e730e3da083877226d8f783d938779023f76b6a1012e8587a21944cd84491b69b376c3ab9d334ee81e4b7e87301ccfa0c44
   languageName: node
   linkType: hard
 
@@ -11062,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^35.7.5"
+    electron: "npm:^36.9.5"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,16 +4827,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^32.1.2":
-  version: 32.1.2
-  resolution: "electron@npm:32.1.2"
+"electron@npm:^33.4.11":
+  version: 33.4.11
+  resolution: "electron@npm:33.4.11"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/9e453e046e024b1454fb212e977d622feba3b6d24ff922a360c06177ec8bcbe58e729e105260285e79c0a203dfcb42d3d795844030bba8681016ab50b7d4bb87
+  checksum: 10c0/fbc8104454eec5c4693792b236eda028ff4d0025654be972a055ae9314a8b9ac801f28bf9847233eeae584874f633fd7794627d01cd2367a304b133bfee879f5
   languageName: node
   linkType: hard
 
@@ -11053,7 +11053,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^32.1.2"
+    electron: "npm:^33.4.11"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2706,12 +2706,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.16.11, @types/node@npm:^20.9.0":
+"@types/node@npm:^20.16.11":
   version: 20.16.11
   resolution: "@types/node@npm:20.16.11"
   dependencies:
     undici-types: "npm:~6.19.2"
   checksum: 10c0/bba43f447c3c80548513954dae174e18132e9149d572c09df4a282772960d33e229d05680fb5364997c03489c22fe377d1dbcd018a3d4ff1cfbcfcdaa594a9c3
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.7.7":
+  version: 22.19.19
+  resolution: "@types/node@npm:22.19.19"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/402e0f088c94cabda3cd721546bd8e4e75e098e0b342f6e03b90ca1e19c28986f9650112c64fcfd09fc8cebc0f8b20291a513153e90489331cf666e1e5503e16
   languageName: node
   linkType: hard
 
@@ -4827,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^34.5.8":
-  version: 34.5.8
-  resolution: "electron@npm:34.5.8"
+"electron@npm:^35.7.5":
+  version: 35.7.5
+  resolution: "electron@npm:35.7.5"
   dependencies:
     "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^20.9.0"
+    "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/1fd2975d41f3ef29e165f5677137c6ce6f69ec8e7f5db9db14cfd6859c8b28ea4bc91a83cc646551918f634034ffd2cde417a5ff7631e401ca5bcb711db1aa9f
+  checksum: 10c0/2c331e438b655b25a8b49ce038878cdc61a42481fcdf464ecb5648585a2c83f1edc5d8e0a8de582713f8e3dc8a3b35aaa136735ad68f8009ee2369f3b2e79c15
   languageName: node
   linkType: hard
 
@@ -11053,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^34.5.8"
+    electron: "npm:^35.7.5"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"
@@ -11501,6 +11510,13 @@ __metadata:
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,16 +4827,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^33.4.11":
-  version: 33.4.11
-  resolution: "electron@npm:33.4.11"
+"electron@npm:^34.5.8":
+  version: 34.5.8
+  resolution: "electron@npm:34.5.8"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/fbc8104454eec5c4693792b236eda028ff4d0025654be972a055ae9314a8b9ac801f28bf9847233eeae584874f633fd7794627d01cd2367a304b133bfee879f5
+  checksum: 10c0/1fd2975d41f3ef29e165f5677137c6ce6f69ec8e7f5db9db14cfd6859c8b28ea4bc91a83cc646551918f634034ffd2cde417a5ff7631e401ca5bcb711db1aa9f
   languageName: node
   linkType: hard
 
@@ -11053,7 +11053,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^33.4.11"
+    electron: "npm:^34.5.8"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^40.10.0":
-  version: 40.10.0
-  resolution: "electron@npm:40.10.0"
+"electron@npm:^41.5.2":
+  version: 41.5.2
+  resolution: "electron@npm:41.5.2"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^24.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/437e9804341ed03295f65c119221bdd8bb9a370234a93733ced623320414531b60cfb0aa379744d42c0f8cb63c6c7946feb188ea0e2bd99e5729abfefef2ac7c
+  checksum: 10c0/339db55c92157204a5ff2abb96c457dab3474d04523cf86a0bbbb729cf76f6f8ee57c8299a0f1571ace5584783e85af4a1ebf317c5c20c5f3d80395db13912a5
   languageName: node
   linkType: hard
 
@@ -11062,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^40.10.0"
+    electron: "npm:^41.5.2"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^36.9.5":
-  version: 36.9.5
-  resolution: "electron@npm:36.9.5"
+"electron@npm:^37.10.3":
+  version: 37.10.3
+  resolution: "electron@npm:37.10.3"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/85f7239e6912dba8dcab133b51c12e730e3da083877226d8f783d938779023f76b6a1012e8587a21944cd84491b69b376c3ab9d334ee81e4b7e87301ccfa0c44
+  checksum: 10c0/a09c10d76be021a94f6c8b251ef990553fe530a6a1271c22026f06a502e977fac116a88b78e73abf50177386a76d69b1c9a52f62d6de60006cc50ed4cb969f0f
   languageName: node
   linkType: hard
 
@@ -11062,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^36.9.5"
+    electron: "npm:^37.10.3"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,12 +2715,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.7.7":
-  version: 22.19.19
-  resolution: "@types/node@npm:22.19.19"
+"@types/node@npm:^24.9.0":
+  version: 24.12.4
+  resolution: "@types/node@npm:24.12.4"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10c0/402e0f088c94cabda3cd721546bd8e4e75e098e0b342f6e03b90ca1e19c28986f9650112c64fcfd09fc8cebc0f8b20291a513153e90489331cf666e1e5503e16
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/d2c36b78b6050d8677769fa05a32243061675e81ddc2bb43955d91a671af3465506ef2731a24c0c9ab42b6b679bd5c1513de45bbe9ea278c2c07ee63b564b61b
   languageName: node
   linkType: hard
 
@@ -4836,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^39.8.10":
-  version: 39.8.10
-  resolution: "electron@npm:39.8.10"
+"electron@npm:^40.10.0":
+  version: 40.10.0
+  resolution: "electron@npm:40.10.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^22.7.7"
+    "@types/node": "npm:^24.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/a62fc5a9d2cf96b4684547e14d2a9a1dc4350d66bcfdd2747d4154d6af3bdf8e4e0aae21dfaee55617035b870a3326b61102ef84b7bed5cd73040ec9b0ebe595
+  checksum: 10c0/437e9804341ed03295f65c119221bdd8bb9a370234a93733ced623320414531b60cfb0aa379744d42c0f8cb63c6c7946feb188ea0e2bd99e5729abfefef2ac7c
   languageName: node
   linkType: hard
 
@@ -11062,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^39.8.10"
+    electron: "npm:^40.10.0"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"
@@ -11513,10 +11513,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4711,15 +4711,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-devtools-installer@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "electron-devtools-installer@npm:3.2.0"
+"electron-devtools-installer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "electron-devtools-installer@npm:4.0.0"
   dependencies:
-    rimraf: "npm:^3.0.2"
-    semver: "npm:^7.2.1"
-    tslib: "npm:^2.1.0"
     unzip-crx-3: "npm:^0.2.0"
-  checksum: 10c0/50d56e174e3bbe568d3d4a56a56e8c87faf44aa54a49ecc93ab672905f30ca1bf4e6a1b5a0b297c6ffeec1e89848086a6ff47f0db8197edb16d1bda16d6440c2
+  checksum: 10c0/54ba5b7c5f51b9e9857d840fd8ab1958c80efe1c71ad1455f0c93fb3d87696261a429453d561074edcf5e2296b37e1bc65c98b61281ec704add8a563f454f4d0
   languageName: node
   linkType: hard
 
@@ -11063,7 +11060,7 @@ __metadata:
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
     electron: "npm:^41.5.2"
-    electron-devtools-installer: "npm:^3.2.0"
+    electron-devtools-installer: "npm:^4.0.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"
     eslint: "npm:^8.57.1"
@@ -11350,7 +11347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.1, tslib@npm:^2.1.0":
+"tslib@npm:^2.0.1":
   version: 2.7.0
   resolution: "tslib@npm:2.7.0"
   checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,16 +4836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^38.8.6":
-  version: 38.8.6
-  resolution: "electron@npm:38.8.6"
+"electron@npm:^39.8.10":
+  version: 39.8.10
+  resolution: "electron@npm:39.8.10"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/4e3c02a01b99a77d715a28ec1b1053382860c3100a735adae5784387e38f7cb800313aeb2c9d292297f37237b57b8660bafcf913360a6b68865a45642a495264
+  checksum: 10c0/a62fc5a9d2cf96b4684547e14d2a9a1dc4350d66bcfdd2747d4154d6af3bdf8e4e0aae21dfaee55617035b870a3326b61102ef84b7bed5cd73040ec9b0ebe595
   languageName: node
   linkType: hard
 
@@ -11062,7 +11062,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     antd: "npm:^5.21.3"
     chromatic: "npm:^11.0.0"
-    electron: "npm:^38.8.6"
+    electron: "npm:^39.8.10"
     electron-devtools-installer: "npm:^3.2.0"
     electron-log: "npm:^5.2.0"
     electron-squirrel-startup: "npm:^1.0.0"


### PR DESCRIPTION
- **chore: upgrade electron from v32 to v33 (33.4.11)**
- **chore: upgrade electron from v33 to v34 (34.5.8)**
- **chore: upgrade electron from v34 to v35 (35.7.5)**
- **chore: upgrade electron from v35 to v36 (36.9.5)**
- **chore: upgrade electron from v36 to v37 (37.10.3)**
- **chore: upgrade electron from v37 to v38 (38.8.6)**
- **chore: upgrade electron from v38 to v39 (39.8.10)**
- **chore: upgrade electron from v39 to v40 (40.10.0)**
- **chore: upgrade electron from v40 to v41 (41.5.2)**
- **chore: upgrade electron-devtools-installer from v3 to v4**
