### PR TITLE
feat: enrich SQL completion with full keyword list and multi-engine support

### DIFF
--- a/src/renderer/component/MonacoEditor/useCompletion.test.ts
+++ b/src/renderer/component/MonacoEditor/useCompletion.test.ts
@@ -5,10 +5,12 @@ import * as monaco from 'monaco-editor';
 import { describe, expect, test, vi } from 'vitest';
 import { ColumnDetailHelper } from '../../../sql/ColumnDetailHelper';
 import { ForeignKeysHelper } from '../../../sql/ForeignKeysHelper';
+import { KEYWORDS_BY_ENGINE } from '../../../sql/keywords';
 import { ShowTableStatus } from '../../../sql/types';
 import { testables } from './useCompletion';
 
-const { provideCompletionItems, SQL_KEYWORDS } = testables;
+const { provideCompletionItems } = testables;
+const SQL_KEYWORDS = KEYWORDS_BY_ENGINE['mysql'];
 
 describe('sql keywords', () => {
   test.each([

--- a/src/renderer/component/MonacoEditor/useCompletion.tsx
+++ b/src/renderer/component/MonacoEditor/useCompletion.tsx
@@ -11,25 +11,12 @@ import { useForeignKeysContext } from '../../../contexts/ForeignKeysContext';
 import { useTableListContext } from '../../../contexts/TableListContext';
 import { ColumnDetailHelper } from '../../../sql/ColumnDetailHelper';
 import { ForeignKeysHelper } from '../../../sql/ForeignKeysHelper';
+import { KEYWORDS_BY_ENGINE, SqlEngine } from '../../../sql/keywords';
 import {
   extractTableAliases,
   generateTableAlias,
 } from '../../../sql/tableName';
 import { ShowTableStatus } from '../../../sql/types';
-
-const SQL_KEYWORDS = [
-  'SELECT',
-  'FROM',
-  'WHERE',
-  'AND',
-  'OR',
-  'JOIN',
-  'LEFT JOIN',
-  'RIGHT JOIN',
-  'INNER JOIN',
-  'ON',
-  'LIMIT',
-];
 
 type MonacoApi = Pick<typeof import('monaco-editor'), 'Range' | 'languages'>;
 
@@ -37,8 +24,10 @@ function provideCompletionItems(
   monaco: MonacoApi,
   tableList: ShowTableStatus[],
   foreignKeys: ForeignKeysHelper,
-  allColumns: ColumnDetailHelper
+  allColumns: ColumnDetailHelper,
+  engine: SqlEngine = 'mysql'
 ): languages.CompletionItemProvider['provideCompletionItems'] {
+  const SQL_KEYWORDS = KEYWORDS_BY_ENGINE[engine];
   return (
     model: editor.ITextModel,
     position: Position,
@@ -190,7 +179,8 @@ function provideCompletionItems(
 }
 
 export default function useCompletion(
-  monaco: typeof import('monaco-editor') | null
+  monaco: typeof import('monaco-editor') | null,
+  engine: SqlEngine = 'mysql'
 ) {
   const tableList = useTableListContext();
   const foreignKeys = useForeignKeysContext();
@@ -210,7 +200,8 @@ export default function useCompletion(
           monaco,
           tableList,
           foreignKeys,
-          allColumns
+          allColumns,
+          engine
         ),
         // This function can be used to resolve additional information for the item that is being auto completed.
         // resolveCompletionItem: async (item, token) => {
@@ -226,10 +217,9 @@ export default function useCompletion(
     return () => {
       completionItemProvider.dispose();
     };
-  }, [allColumns, foreignKeys, monaco, tableList]);
+  }, [allColumns, engine, foreignKeys, monaco, tableList]);
 }
 
 export const testables = {
   provideCompletionItems,
-  SQL_KEYWORDS,
 };

--- a/src/sql/keywords.ts
+++ b/src/sql/keywords.ts
@@ -499,6 +499,14 @@ const MYSQL_RESERVED_KEYWORDS = [
   'ZEROFILL',
 ];
 
+export type SqlEngine = 'generic' | 'mysql';
+
+export const KEYWORDS_BY_ENGINE: Record<SqlEngine, readonly string[]> = {
+  generic: SQL_2023_RESERVED_KEYWORDS,
+  mysql: [...SQL_2023_RESERVED_KEYWORDS, ...MYSQL_RESERVED_KEYWORDS],
+};
+
+// kept for existing usages (alias generation, etc.)
 export const SQL_RESERVED_KEYWORDS = [
   ...SQL_2023_RESERVED_KEYWORDS,
   ...MYSQL_RESERVED_KEYWORDS,


### PR DESCRIPTION
## Summary

- Replace the 12 hardcoded SQL keywords with the full list from `keywords.ts` (498 keywords: SQL 2023 standard + MySQL specifics)
- Add `SqlEngine` type and `KEYWORDS_BY_ENGINE` map to `keywords.ts` to prepare multi-engine support (`postgresql`, `sqlite`, etc. can be added later without touching the completion logic)
- Expose an `engine` parameter on `useCompletion` hook (default: `'mysql'`)

## Test plan

- [ ] All 138 existing tests pass
- [ ] SQL autocompletion now suggests functions like `ABS`, `CONCAT`, `DATE_ADD`, etc. in addition to keywords
- [ ] Custom logic (alias generation, FK-based JOIN suggestions, column suggestions after `.`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)