### PR TITLE
Revert partially https://github.com/jdeniau/tiana-tables/pull/132

### DIFF
--- a/src/contexts/ConfigurationContext.tsx
+++ b/src/contexts/ConfigurationContext.tsx
@@ -1,6 +1,4 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { DEFAULT_LOCALE } from '../configuration/locale';
-import { DEFAULT_THEME } from '../configuration/themes';
 import { Configuration } from '../configuration/type';
 import { changeLanguage } from '../i18n';
 import { ConnectionObjectWithoutSlug } from '../sql/types';
@@ -25,22 +23,15 @@ const ConfigurationContext = createContext<null | ConfigurationContextType>(
   null
 );
 ConfigurationContext.displayName = 'ConfigurationContext';
-const DEFAULT_CONFIGURATION_VERSION = 1;
 
-const DEFAULT_CONFIGURATION: Configuration = {
-  version: DEFAULT_CONFIGURATION_VERSION,
-  theme: DEFAULT_THEME.name,
-  locale: DEFAULT_LOCALE,
-  connections: {},
+type Props = {
+  children: React.ReactNode;
 };
 
-export function ConfigurationContextProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [configuration, setConfiguration] =
-    useState<Configuration>(DEFAULT_CONFIGURATION);
+export function ConfigurationContextProvider({ children }: Props) {
+  const [configuration, setConfiguration] = useState<Configuration | null>(
+    null
+  );
 
   useEffect(() => {
     let isCanceled = false;
@@ -73,7 +64,9 @@ export function ConfigurationContextProvider({
 
   const value: ConfigurationContextType = useMemo(
     (): ConfigurationContextType => ({
-      configuration,
+      // force `as` here as we will break if configuration is null, but the hook needs to be before it.
+      // We don't want to use ts-expect-error, as we want to test other properties of the object.
+      configuration: configuration as Configuration,
       addConnectionToConfig: willChangeConfiguration(
         window.config.addConnectionToConfig
       ),
@@ -88,6 +81,10 @@ export function ConfigurationContextProvider({
     }),
     [configuration]
   );
+
+  if (!configuration) {
+    return null;
+  }
 
   return (
     <ConfigurationContext.Provider value={value}>


### PR DESCRIPTION
having an empty default configuration would have unexpected behavior (like redirect on /create at startup)