### PR TITLE
Replace the table alias regex by dt-sql-parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,21 @@ Translation files are in `locales/` (`en.ts`, `fr.ts`). English (`en.ts`) is the
 | Storybook 8                | Component development                                        |
 | TypeScript 6               | Type checking                                                |
 
+### SQL statements
+
+**A query sent to the server MUST always be a single statement.** `multipleStatements`
+stays off in the mysql2 connection, and the editor is expected to send one
+statement at a time.
+
+When the editor holds several statements, they are to be split and handled
+independently, and the one **under the caret** is the one that gets sent —
+and the one that completion, highlighting and validation work on.
+
+`dt-sql-parser` exposes `splitSQLByStatement`, but beware: it returns `null` as
+soon as the input has any syntax error (`SELECT FROM t1 a` included), so it
+cannot be used as a "is the tail unfinished?" check. Splitting on the `;` tokens
+of `getAllTokens` is error-tolerant, since lexing never fails.
+
 ### Gotchas
 
 - **Tests default to the node environment.** Add `/** @vitest-environment happy-dom */` at the top of a test file that needs the DOM (see `src/renderer/routes/connections.$connectionSlug.$databaseName.test.tsx`).

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tanstack/react-table": "^9.1.2",
     "@tanstack/react-virtual": "^3.14.9",
     "antd": "^6.4.2",
+    "dt-sql-parser": "^4.5.0",
     "electron-log": "^5.4.3",
     "electron-squirrel-startup": "^1.0.1",
     "fuse.js": "^7.3.0",

--- a/src/sql/tableName.test.ts
+++ b/src/sql/tableName.test.ts
@@ -85,4 +85,27 @@ describe('extractTableAliases', () => {
   ])('table aliases', (sql, expected) => {
     expect(extractTableAliases(sql)).toEqual(expected);
   });
+
+  // The editor parses on every keystroke, so the query is usually unfinished.
+  // A syntax error makes the parser drop the whole statement, tables included,
+  // hence the trimming in `collectEntities`.
+  test.each([
+    ['SELECT * FROM t1 a JOIN ', { a: 't1' }],
+    ['SELECT * FROM t1 a JOIN t2 b ON ', { a: 't1', b: 't2' }],
+    ['SELECT * FROM t1 a WHERE ', { a: 't1' }],
+    ['SELECT * FROM t1 a WHERE x = ', { a: 't1' }],
+    ['SELECT * FROM t1 a ORDER BY ', { a: 't1' }],
+    ['SELECT * FROM t1 a GROUP ', { a: 't1' }],
+    ['SELECT * FROM t1 a LIMIT ', { a: 't1' }],
+    ['SELECT FROM t1 a', { a: 't1' }],
+    ['SELECT 1', {}],
+    ['', {}],
+    // Known limitation: the first statement parses on its own, which stops the
+    // trimming before the unfinished one is reached. Statements are meant to be
+    // split and handled independently, keeping only the one under the caret —
+    // see the "SQL statements" rule in CLAUDE.md.
+    ['SELECT * FROM t1 a; SELECT * FROM t2 b JOIN ', { a: 't1' }],
+  ])('table aliases in unfinished query %j', (sql, expected) => {
+    expect(extractTableAliases(sql)).toEqual(expected);
+  });
 });

--- a/src/sql/tableName.ts
+++ b/src/sql/tableName.ts
@@ -1,3 +1,5 @@
+import { EntityContext, EntityContextType, MySQL } from 'dt-sql-parser';
+import { AttrName } from 'dt-sql-parser/dist/parser/common/entityCollector';
 import { SQL_RESERVED_KEYWORDS } from './keywords';
 
 export function generateTableAlias(
@@ -61,51 +63,85 @@ export function generateTableAlias(
   return newAlias;
 }
 
-// TODO maybe import a list of reserved keywords ? https://en.wikipedia.org/wiki/List_of_SQL_reserved_words
-const FORBIDDEN_ALIASES = [
-  'JOIN',
-  'INNER',
-  'LEFT',
-  'RIGHT',
-  'FULL',
-  'LIMIT',
-  'OFFSET',
-  'ON',
-];
-const FORBIDDEN_ALIASES_JOINED = FORBIDDEN_ALIASES.join('|');
-
-const TABLE_NAME_REGEX = new RegExp(
-  `(from|join)\\s+(?<database>\\w*\\.)?(?<tablename>\\w+)?\\s*(as\\s+)?(?!${FORBIDDEN_ALIASES_JOINED})(?<alias>\\w+)?`,
-  'gi'
-);
-
 type Alias = string;
 type TableName = string;
+
+// the parser holds no state between calls, so a single instance is enough
+const parser = new MySQL();
+
+/** `db1.t1` and `` `t1` `` both refer to the table `t1` */
+function unqualify(tableNamePath: string): TableName {
+  const lastSegment = tableNamePath.split('.').at(-1) ?? tableNamePath;
+
+  return lastSegment.replace(/^[`"[]|[`"\]]$/g, '');
+}
+
+/** an incomplete clause is a few tokens long, no need to trim further */
+const MAX_TRIM_ATTEMPTS = 8;
+
 /**
- * Extract all table names from the given query.
- * This function does not check that the table exist,
- * but do only extract the table names from the SQL syntax
+ * Collect the entities of a query, tolerating an unfinished tail.
+ *
+ * Entity collection is all or nothing: as soon as the statement has a syntax
+ * error, ANTLR cannot pick an alternative for the enclosing rule and drops the
+ * whole subtree, so `getAllEntities` returns nothing — not even the tables
+ * written before the error. That is exactly what the editor sends while the
+ * user is still typing (`… JOIN `, `… WHERE x = `, `… ORDER BY `), so retry on
+ * shorter prefixes, dropping the trailing token each time.
+ *
+ * Lexing, on the other hand, never fails, which is what gives us the token
+ * boundaries to cut on.
+ */
+function collectEntities(sql: string): EntityContext[] {
+  let candidate = sql;
+
+  for (let attempt = 0; attempt <= MAX_TRIM_ATTEMPTS; attempt++) {
+    const entities = parser.getAllEntities(candidate);
+
+    if (entities?.length) {
+      return entities;
+    }
+
+    const lastToken = parser
+      .getAllTokens(candidate)
+      .filter((token) => token.text?.trim())
+      .at(-1);
+
+    const shorter = lastToken ? candidate.slice(0, lastToken.start) : '';
+
+    if (shorter.length >= candidate.length) {
+      break;
+    }
+
+    candidate = shorter;
+
+    if (!candidate.trim()) {
+      break;
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Extract all table names from the given query, indexed by their alias (or by
+ * their own name when they have none).
+ *
+ * This function does not check that the tables exist, it only reads the SQL.
+ * Incomplete queries are expected: the parser reports syntax errors instead of
+ * throwing, and still returns the entities it managed to resolve.
  */
 export function extractTableAliases(sql: string): Record<Alias, TableName> {
-  const matches = sql.matchAll(TABLE_NAME_REGEX);
-
-  const arrayMatches = [...matches];
-
-  // console.log(arrayMatches);
+  const tables = collectEntities(sql).filter(
+    (entity) => entity.entityContextType === EntityContextType.TABLE
+  );
 
   return Object.fromEntries(
-    arrayMatches
-      .filter((match) => {
-        const alias = match.groups?.alias;
+    tables.map((table) => {
+      const tableName = unqualify(table.text);
+      const alias = table[AttrName.alias]?.text;
 
-        return (
-          typeof alias === 'undefined' ||
-          (typeof alias === 'string' && !FORBIDDEN_ALIASES.includes(alias))
-        );
-      })
-      .map((match) => [
-        match.groups?.alias ?? match.groups?.tablename,
-        match.groups?.tablename,
-      ])
+      return [alias ?? tableName, tableName];
+    })
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4384,6 +4384,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"antlr4-c3@npm:3.3.7":
+  version: 3.3.7
+  resolution: "antlr4-c3@npm:3.3.7"
+  dependencies:
+    antlr4ng: "npm:2.0.11"
+  checksum: 10c0/f2ab548e3de2ab40a4dc7982f8ea8261f5166eba0eef45662ffe34befe922ff6ec038311ff203805b5044f6a95b0d975e19292655a9bd1435dc003fd44669409
+  languageName: node
+  linkType: hard
+
+"antlr4ng@npm:2.0.11":
+  version: 2.0.11
+  resolution: "antlr4ng@npm:2.0.11"
+  peerDependencies:
+    antlr4ng-cli: 1.0.7
+  checksum: 10c0/48dc65e39af6f4e8ebe491bd184de910fcb850bc02b43a5d96df0b34370c534a5bee970ca7f8a9f95678cc32f9e74ff123d1ea82f56918435592078d0b8f2115
+  languageName: node
+  linkType: hard
+
 "appdmg@npm:^0.6.4":
   version: 0.6.6
   resolution: "appdmg@npm:0.6.6"
@@ -5534,6 +5552,16 @@ __metadata:
     macos-alias: "npm:~0.2.5"
     tn1150: "npm:^0.1.0"
   checksum: 10c0/40293e925e27fa6df7f043320a2e277c5901368c49a7e420ecfc510dd843a6878b92875b126b841b53a70be7a6ab67338582b7f7ffd4ace3e581cf15aea0a1e2
+  languageName: node
+  linkType: hard
+
+"dt-sql-parser@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "dt-sql-parser@npm:4.5.0"
+  dependencies:
+    antlr4-c3: "npm:3.3.7"
+    antlr4ng: "npm:2.0.11"
+  checksum: 10c0/ef917ad4e7115fec2432ee6ddd589d3bc8cf026d86a58ed3072e383e8177315321a996844562505c695f60eec338d1c42db1ede82e21ef58ed6e8508b3bb2a42
   languageName: node
   linkType: hard
 
@@ -11115,6 +11143,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^6.0.1"
     antd: "npm:^6.4.2"
     chromatic: "npm:^11.29.0"
+    dt-sql-parser: "npm:^4.5.0"
     electron: "npm:^41.5.2"
     electron-devtools-installer: "npm:^4.0.0"
     electron-log: "npm:^5.4.3"


### PR DESCRIPTION
## Why

`extractTableAliases` read `FROM`/`JOIN` clauses with a hand-written regex and a
hardcoded list of forbidden aliases (`JOIN`, `INNER`, `LEFT`, `ON`…). It works
until it doesn't: quoted identifiers, comma joins, subqueries, `WITH` — every
new shape means another regex tweak.

This is also the groundwork for SQL semantic highlighting: rather than adding a
*second* hand-written parser next to this one, both now share a real grammar.

## What

`extractTableAliases` delegates to [dt-sql-parser](https://github.com/DTStack/dt-sql-parser)
(ANTLR-based, MySQL grammar, built for editors). Same signature, same tests —
plus the shapes the regex never covered.

## The catch: entity collection is all or nothing

As soon as a statement has a syntax error, ANTLR cannot pick an alternative for
the enclosing rule and drops the whole subtree, so `getAllEntities` returns
**nothing** — not even the tables written *before* the error:

| query | tables found |
|---|---|
| `SELECT * FROM t1 a WHERE ` | `t1/a` |
| `SELECT * FROM t1 a JOIN ` | **none** |
| `SELECT * FROM t1 a WHERE x = ` | **none** |
| `SELECT * FROM t1 a ORDER BY ` | **none** |

That is exactly what the editor sends while the user is typing a join. So
`collectEntities` retries on shorter prefixes, dropping the trailing token each
time until the parser resolves something. Lexing never fails, which is what
gives the token boundaries to cut on — no SQL keyword list on our side, the
grammar knowledge stays in the library.

Cost: 2–4 parses instead of 1 on a query being typed, 1 on a complete one.

## Tests

11 new cases covering unfinished queries, including one **known limitation**:
with several statements, the first valid one stops the trimming before the
unfinished one is reached. Harmless today — a query must always be a single
statement (`multipleStatements` is off), a rule now written down in `CLAUDE.md`
along with the plan to split statements and keep the one under the caret.

`yarn lint` and the 470 tests pass.

## Next

Stacked PR: SQL semantic highlighting (colouring tables, columns and aliases),
built on `getAllTokens` + `getAllEntities` + the schema the app already knows.