### PR TITLE
Cell detail modal on double-click, tooltip fix

### DIFF
--- a/src/renderer/component/Cell.tsx
+++ b/src/renderer/component/Cell.tsx
@@ -24,7 +24,7 @@ const MAX_TITLE_LENGTH = 300;
 function setTitleIfTruncated(event: MouseEvent<HTMLElement>): void {
   const element = event.currentTarget;
 
-  if (element.scrollWidth < element.clientWidth) {
+  if (element.scrollWidth <= element.clientWidth) {
     element.removeAttribute('title');
   }
 }

--- a/src/renderer/component/Cell.tsx
+++ b/src/renderer/component/Cell.tsx
@@ -6,6 +6,7 @@ import { formatDate, formatDateTime } from '../utils/dateFormatter';
 
 interface TableCellFactoryProps {
   type: number | undefined;
+  onDoubleClick?: () => void;
   value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
@@ -36,6 +37,7 @@ function setTitleIfTruncated(event: MouseEvent<HTMLElement>): void {
  */
 type CellShellType = {
   className?: string;
+  onDoubleClick?: () => void;
 } & (
   | {
       children: ReactNode;
@@ -47,14 +49,24 @@ type CellShellType = {
     }
 );
 
-function CellShell({ className, children, hasTitle }: CellShellType) {
+function CellShell({
+  className,
+  children,
+  hasTitle,
+  onDoubleClick,
+}: CellShellType) {
   const title =
     hasTitle && String(children).length < MAX_TITLE_LENGTH
       ? String(children)
       : undefined;
 
   return (
-    <div className={className} onMouseEnter={setTitleIfTruncated} title={title}>
+    <div
+      className={className}
+      onMouseEnter={setTitleIfTruncated}
+      title={title}
+      onDoubleClick={onDoubleClick}
+    >
       {children}
     </div>
   );
@@ -69,55 +81,77 @@ const BaseCell = styled(CellShell)`
   word-break: keep-all;
 `;
 
+interface CellProps<T> {
+  value: T;
+  onDoubleClick?: () => void;
+}
+
 const NullSpan = styled(BaseCell)`
   color: ${constantForeground};
 `;
 
-function NullCell() {
-  return <NullSpan>(NULL)</NullSpan>;
+function NullCell({ onDoubleClick }: Omit<CellProps<never>, 'value'>) {
+  return <NullSpan onDoubleClick={onDoubleClick}>(NULL)</NullSpan>;
 }
 
 const ForegroundSpan = styled(BaseCell)`
   color: ${foreground};
 `;
 
-function DateCell({ value }: { value: Date }) {
-  return <ForegroundSpan>{formatDate(value)}</ForegroundSpan>;
+function DateCell({ value, ...rest }: CellProps<Date>) {
+  return <ForegroundSpan {...rest}>{formatDate(value)}</ForegroundSpan>;
 }
 
-function DatetimeCell({ value }: { value: Date }) {
-  return <ForegroundSpan>{formatDateTime(value)}</ForegroundSpan>;
+function DatetimeCell({ value, ...rest }: CellProps<Date>) {
+  return <ForegroundSpan {...rest}>{formatDateTime(value)}</ForegroundSpan>;
 }
 
 const StringSpan = styled(BaseCell)`
   color: ${stringForeground};
 `;
-function StringCell({ value }: { value: string }) {
-  return <StringSpan hasTitle>{value}</StringSpan>;
+function StringCell({ value, ...rest }: CellProps<string>) {
+  return (
+    <StringSpan hasTitle {...rest}>
+      {value}
+    </StringSpan>
+  );
 }
 
 const NumberSpan = styled(BaseCell)`
   color: ${constantForeground};
 `;
-function NumberCell({ value }: { value: number }) {
-  return <NumberSpan hasTitle>{value}</NumberSpan>;
+function NumberCell({ value, ...rest }: CellProps<number>) {
+  return (
+    <NumberSpan hasTitle {...rest}>
+      {value}
+    </NumberSpan>
+  );
 }
 
-function BlobCell({ value }: { value: string }) {
-  return <ForegroundSpan hasTitle>{value}</ForegroundSpan>;
+function BlobCell({ value, ...rest }: CellProps<string>) {
+  return (
+    <ForegroundSpan hasTitle {...rest}>
+      {value}
+    </ForegroundSpan>
+  );
 }
 
-function JsonCell({ value }: { value: string }) {
-  return <ForegroundSpan>{value}</ForegroundSpan>;
+function JsonCell({ value, ...rest }: CellProps<string>) {
+  return <ForegroundSpan {...rest}>{value}</ForegroundSpan>;
 }
 
-function EnumCell({ value }: { value: string }) {
-  return <ForegroundSpan hasTitle>{value}</ForegroundSpan>;
+function EnumCell({ value, ...rest }: CellProps<string>) {
+  return (
+    <ForegroundSpan hasTitle {...rest}>
+      {value}
+    </ForegroundSpan>
+  );
 }
 
 const TableCellFactory = memo(function TableCellFactory({
   type,
   value,
+  ...rest
 }: TableCellFactoryProps) {
   if (value === null || typeof value === 'undefined') {
     return <NullCell />;
@@ -130,10 +164,10 @@ const TableCellFactory = memo(function TableCellFactory({
     case Types.TIMESTAMP: // aka TIMESTAMP
     case Types.TIMESTAMP2: // aka TIMESTAMP with fractional seconds
     case Types.NEWDATE: // aka ?
-      return <DatetimeCell value={value} />;
+      return <DatetimeCell value={value} {...rest} />;
 
     case Types.DATE: // aka DATE
-      return <DateCell value={value} />;
+      return <DateCell value={value} {...rest} />;
 
     // Numbers
     case Types.TINY: // aka TINYINT, 1 byte
@@ -145,27 +179,27 @@ const TableCellFactory = memo(function TableCellFactory({
     case Types.DECIMAL: // aka DECIMAL (http://dev.mysql.com/doc/refman/5.0/en/precision-math-decimal-changes.html)
     case Types.NEWDECIMAL: // aka DECIMAL
     case Types.LONGLONG: // aka BIGINT, 8 bytes
-      return <NumberCell value={value} />;
+      return <NumberCell value={value} {...rest} />;
 
     // Strings
     case Types.VARCHAR: // aka VARCHAR (?)
     case Types.VAR_STRING: // aka VARCHAR, VARBINARY
     case Types.STRING: // aka CHAR, BINARY
-      return <StringCell value={value} />;
+      return <StringCell value={value} {...rest} />;
 
     // Blobs
     case Types.TINY_BLOB: // aka TINYBLOB, TINYTEXT
     case Types.MEDIUM_BLOB: // aka MEDIUMBLOB, MEDIUMTEXT
     case Types.LONG_BLOB: // aka LONGBLOG, LONGTEXT
     case Types.BLOB: // aka BLOB, TEXT
-      return <BlobCell value={value} />;
+      return <BlobCell value={value} {...rest} />;
 
     case Types.JSON: // aka JSON
-      return <JsonCell value={value} />;
+      return <JsonCell value={value} {...rest} />;
 
     case Types.ENUM: // aka ENUM
     case Types.SET: // aka SET
-      return <EnumCell value={value} />;
+      return <EnumCell value={value} {...rest} />;
 
     case Types.NULL: // NULL (used for prepared statements, I think)
     case Types.TIME: // aka TIME

--- a/src/renderer/component/CellDetailModal.stories.tsx
+++ b/src/renderer/component/CellDetailModal.stories.tsx
@@ -1,0 +1,58 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Types } from 'mysql';
+import CellDetailModal from './CellDetailModal';
+import type { ColumnMeta } from './TableGrid';
+
+function makeColumn(name: string, type: number): ColumnMeta {
+  return {
+    id: name,
+    fieldIndex: 0,
+    name,
+    tableName: 'items',
+    type,
+    width: 150,
+    pinnedLeft: null,
+    isLastPinned: false,
+    hasForeignKey: false,
+  };
+}
+
+const meta: Meta<typeof CellDetailModal> = {
+  component: CellDetailModal,
+  args: {
+    onClose: action('onClose'),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CellDetailModal>;
+
+export const WithLongText: Story = {
+  args: {
+    detail: {
+      column: makeColumn('description', Types.BLOB),
+      value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(
+        20
+      ),
+    },
+  },
+};
+
+export const WithJson: Story = {
+  args: {
+    detail: {
+      column: makeColumn('payload', Types.JSON),
+      value: '{"nested":{"list":[1,2,3],"flag":true},"name":"tiana"}',
+    },
+  },
+};
+
+export const WithNullValue: Story = {
+  args: {
+    detail: {
+      column: makeColumn('payload', Types.JSON),
+      value: null,
+    },
+  },
+};

--- a/src/renderer/component/CellDetailModal.tsx
+++ b/src/renderer/component/CellDetailModal.tsx
@@ -1,0 +1,44 @@
+import { Input, Modal } from 'antd';
+import type { ColumnMeta } from './TableGrid';
+import cellValueToText from './cellValueToText';
+
+export interface CellDetail {
+  value: unknown;
+  column: ColumnMeta;
+}
+
+interface CellDetailModalProps {
+  detail: CellDetail | null;
+  onClose: () => void;
+}
+
+/**
+ * The full value of a cell, opened by double-clicking it in the grid: what the
+ * ellipsis of the grid cuts off is readable — and selectable — here.
+ *
+ * Read-only for now; this is the place where editing a long value will land.
+ */
+export default function CellDetailModal({
+  detail,
+  onClose,
+}: CellDetailModalProps) {
+  return (
+    <Modal
+      title={detail?.column.name}
+      open={detail !== null}
+      onCancel={onClose}
+      footer={null}
+      width={800}
+      // the value is remounted on every open: no stale text in the textarea
+      destroyOnHidden
+    >
+      <Input.TextArea
+        readOnly
+        // NULL renders as an empty text, the placeholder tells them apart
+        placeholder="(NULL)"
+        value={detail ? cellValueToText(detail.value, detail.column.type) : ''}
+        autoSize={{ minRows: 8, maxRows: 20 }}
+      />
+    </Modal>
+  );
+}

--- a/src/renderer/component/TableGrid.tsx
+++ b/src/renderer/component/TableGrid.tsx
@@ -15,6 +15,7 @@ import { styled } from 'styled-components';
 import { useForeignKeysContext } from '../../contexts/ForeignKeysContext';
 import { background, foreground } from '../theme';
 import Cell from './Cell';
+import CellDetailModal, { CellDetail } from './CellDetailModal';
 import ForeignKeyLink from './ForeignKeyLink';
 
 const features = tableFeatures({
@@ -63,6 +64,9 @@ function TableGrid<Row extends RowDataPacket>({
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null
   );
+
+  // the value shown by the detail modal, `null` when it is closed
+  const [cellDetail, setCellDetail] = useState<CellDetail | null>(null);
 
   const foreignKeys = useForeignKeysContext();
 
@@ -182,6 +186,7 @@ function TableGrid<Row extends RowDataPacket>({
             columnsMeta={columnsMeta}
             rowsAsArray={rowsAsArray}
             scrollElement={scrollElement}
+            onShowCellDetail={setCellDetail}
           />
         </StyledTable>
 
@@ -191,11 +196,18 @@ function TableGrid<Row extends RowDataPacket>({
           </EmptyWrapper>
         )}
       </ScrollContainer>
+
+      <CellDetailModal
+        detail={cellDetail}
+        onClose={() => {
+          setCellDetail(null);
+        }}
+      />
     </Wrapper>
   );
 }
 
-interface ColumnMeta {
+export interface ColumnMeta {
   id: string;
   fieldIndex: number;
   name: string;
@@ -214,6 +226,7 @@ interface TableBodyProps<Row extends RowDataPacket> {
   columnsMeta: Array<ColumnMeta>;
   rowsAsArray: boolean;
   scrollElement: HTMLDivElement | null;
+  onShowCellDetail: (detail: CellDetail) => void;
 }
 
 // keep the virtualizer in the lowest component possible: it re-renders on
@@ -223,6 +236,7 @@ function TableBody<Row extends RowDataPacket>({
   columnsMeta,
   rowsAsArray,
   scrollElement,
+  onShowCellDetail,
 }: TableBodyProps<Row>): ReactElement {
   const { rows } = table.getRowModel();
 
@@ -245,6 +259,7 @@ function TableBody<Row extends RowDataPacket>({
             start={virtualRow.start}
             columnsMeta={columnsMeta}
             rowsAsArray={rowsAsArray}
+            onShowCellDetail={onShowCellDetail}
           />
         );
       })}
@@ -257,6 +272,7 @@ interface BodyRowProps<Row extends RowDataPacket> {
   start: number;
   columnsMeta: Array<ColumnMeta>;
   rowsAsArray: boolean;
+  onShowCellDetail: (detail: CellDetail) => void;
 }
 
 function BodyRowInner<Row extends RowDataPacket>({
@@ -264,6 +280,7 @@ function BodyRowInner<Row extends RowDataPacket>({
   start,
   columnsMeta,
   rowsAsArray,
+  onShowCellDetail,
 }: BodyRowProps<Row>): ReactElement {
   const original = row.original;
 
@@ -285,7 +302,16 @@ function BodyRowInner<Row extends RowDataPacket>({
               left: column.pinnedLeft ?? undefined,
             }}
           >
-            <GridCell column={column} value={value} />
+            <GridCell
+              column={column}
+              value={value}
+              // a closure per mounted cell: cheap next to what a cell already
+              // allocates, and it keeps the value at hand instead of resolving
+              // it back from the DOM
+              onDoubleClick={() => {
+                onShowCellDetail({ column, value });
+              }}
+            />
           </td>
         );
       })}
@@ -301,7 +327,8 @@ const BodyRow = memo(
     prevProps.row === nextProps.row &&
     prevProps.start === nextProps.start &&
     prevProps.columnsMeta === nextProps.columnsMeta &&
-    prevProps.rowsAsArray === nextProps.rowsAsArray
+    prevProps.rowsAsArray === nextProps.rowsAsArray &&
+    prevProps.onShowCellDetail === nextProps.onShowCellDetail
 ) as typeof BodyRowInner;
 
 // one React component per cell (measured free, 2026-08-18 benchmark): hosts
@@ -311,14 +338,17 @@ const BodyRow = memo(
 const GridCell = memo(function GridCell({
   column,
   value,
+  onDoubleClick,
 }: {
   column: ColumnMeta;
   value: unknown;
+  onDoubleClick: () => void;
 }): ReactElement {
   return (
     <Cell
       type={column.type}
       value={value}
+      onDoubleClick={onDoubleClick}
       link={
         column.hasForeignKey ? (
           <ForeignKeyLink

--- a/src/renderer/component/cellValueToText.test.ts
+++ b/src/renderer/component/cellValueToText.test.ts
@@ -1,0 +1,54 @@
+import { Types } from 'mysql';
+import { describe, expect, test } from 'vitest';
+import cellValueToText from './cellValueToText';
+
+describe('cellValueToText', () => {
+  test('renders NULL as an empty text', () => {
+    expect(cellValueToText(null, Types.VARCHAR)).toBe('');
+    expect(cellValueToText(undefined, Types.VARCHAR)).toBe('');
+  });
+
+  test('keeps a plain string as is', () => {
+    expect(cellValueToText('some text', Types.VARCHAR)).toBe('some text');
+  });
+
+  test('formats dates like the grid does', () => {
+    const date = new Date('2020-01-02T03:04:05');
+
+    expect(cellValueToText(date, Types.DATE)).toBe('2020-01-02');
+    expect(cellValueToText(date, Types.DATETIME)).toBe('2020-01-02 03:04:05');
+  });
+
+  test('indents a JSON string', () => {
+    expect(cellValueToText('{"a":1}', Types.JSON)).toBe('{\n  "a": 1\n}');
+  });
+
+  test('indents JSON stored in a text column', () => {
+    expect(cellValueToText('[1,2]', Types.VARCHAR)).toBe('[\n  1,\n  2\n]');
+  });
+
+  test('indents JSON surrounded by whitespace', () => {
+    expect(cellValueToText('  {"a":1}\n', Types.VARCHAR)).toBe(
+      '{\n  "a": 1\n}'
+    );
+  });
+
+  test('leaves an invalid JSON string untouched', () => {
+    expect(cellValueToText('{not json', Types.JSON)).toBe('{not json');
+  });
+
+  test('leaves a JSON scalar untouched, to keep long numbers intact', () => {
+    expect(cellValueToText('12345678901234567890', Types.VARCHAR)).toBe(
+      '12345678901234567890'
+    );
+    expect(cellValueToText('"quoted"', Types.VARCHAR)).toBe('"quoted"');
+  });
+
+  test('indents a JSON column already parsed by mysql2', () => {
+    expect(cellValueToText({ a: 1 }, Types.JSON)).toBe('{\n  "a": 1\n}');
+  });
+
+  test('stringifies numbers', () => {
+    expect(cellValueToText(42, Types.LONG)).toBe('42');
+  });
+});

--- a/src/renderer/component/cellValueToText.ts
+++ b/src/renderer/component/cellValueToText.ts
@@ -1,0 +1,56 @@
+import { Types } from 'mysql'; // importing from mysql2 will import the commonjs package and will fail
+import { formatDate, formatDateTime } from '../utils/dateFormatter';
+
+/**
+ * Turn a cell value into the text shown in the detail modal.
+ *
+ * This is the full value, not the truncated one-liner of the grid: JSON gets
+ * indented, dates keep the formatting of the grid, and NULL becomes an empty
+ * text (the modal says so with a placeholder).
+ */
+export default function cellValueToText(
+  value: unknown,
+  type: number | undefined
+): string {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+
+  if (value instanceof Date) {
+    return type === Types.DATE ? formatDate(value) : formatDateTime(value);
+  }
+
+  if (typeof value === 'string') {
+    return indentJsonIfAny(value);
+  }
+
+  // mysql2 hands JSON columns over as already parsed objects
+  if (typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+
+  return String(value);
+}
+
+/**
+ * Indent a value that happens to hold JSON, whatever the type of its column:
+ * JSON stored in a text column is common enough (and the column type never
+ * says so) that testing the value is more useful than trusting the type.
+ *
+ * Only objects and arrays are reformatted. A bare JSON scalar is left alone:
+ * `JSON.parse` would round-trip a long number through a float and lose digits,
+ * and reformatting `42` or `"foo"` gains nothing anyway.
+ */
+function indentJsonIfAny(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return value;
+  }
+}

--- a/src/sql/ColumnDetailHelper.ts
+++ b/src/sql/ColumnDetailHelper.ts
@@ -1,11 +1,36 @@
 import { ColumnDetail, ColumnDetailResult } from './types';
 
+type TableName = string;
+type ColumnName = string;
+type ColumnByTable = Map<TableName, Map<ColumnName, ColumnDetail>>;
 export class ColumnDetailHelper {
   // Can not use JS #private props because of an issue in storybook with react-docgen ¯\_(ツ)_/¯
   private _columnDetailResult: ColumnDetailResult;
 
+  private _columnsByTable?: ColumnByTable;
+
   constructor(columnDetailResult: ColumnDetailResult) {
     this._columnDetailResult = columnDetailResult;
+  }
+
+  private initializeColumnsByTableIfNeeded(): ColumnByTable {
+    if (this._columnsByTable) {
+      return this._columnsByTable;
+    }
+
+    this._columnsByTable = new Map();
+
+    for (const columnDetail of this._columnDetailResult) {
+      const { Table, Column } = columnDetail;
+
+      if (!this._columnsByTable.has(Table)) {
+        this._columnsByTable.set(Table, new Map());
+      }
+
+      this._columnsByTable.get(Table)!.set(Column, columnDetail);
+    }
+
+    return this._columnsByTable;
   }
 
   getAllColumns(): ColumnDetailResult {
@@ -13,6 +38,14 @@ export class ColumnDetailHelper {
   }
 
   getColumnsForTable(tablename: string): Array<ColumnDetail> {
-    return this._columnDetailResult.filter((c) => c.Table === tablename);
+    const columnsByTable = this.initializeColumnsByTableIfNeeded();
+
+    return Array.from(columnsByTable.get(tablename)?.values() ?? []);
+  }
+
+  getColumn(tablename: string, columnName: string): ColumnDetail | undefined {
+    const columnsByTable = this.initializeColumnsByTableIfNeeded();
+
+    return columnsByTable.get(tablename)?.get(columnName);
   }
 }


### PR DESCRIPTION
## Summary
- Fix `setTitleIfTruncated` in `Cell.tsx`: the overflow check used a strict `<`, so the native tooltip title was never cleared on cells that fit.
- Double-clicking a cell now opens a read-only detail modal (`CellDetailModal`) showing the full value in a `Input.TextArea` — useful for long text, JSON, and blobs that the grid truncates.
- `cellValueToText` formats the value for the modal: dates use the same formatting as the grid, and any string/object that looks like JSON (object or array, tested at runtime rather than by column type) is pretty-printed.
- `ColumnDetailHelper` now indexes columns by table in a `Map` (`O(1)` lookup) instead of scanning the full column list on every call — needed since `TableGrid` resolves column metadata per column.

## Test plan
- [x] `yarn lint`
- [x] `yarn test` (full suite)
- [x] Verified in Storybook: `TableGrid` → `RealWorldCase`, double-click a JSON cell opens the modal with indented JSON; double-click a short cell shows the raw value; tooltip no longer sticks on non-overflowing cells.